### PR TITLE
Check in CI that frontend can build

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,4 +1,4 @@
-name: Backend Tests
+name: CI Checks
 
 on: push
 
@@ -13,10 +13,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
-    - name: Install dependencies
+    - name: Verify production build of frontend
       run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Test with pytest
-      run: |
-        ./bin/test
+        ./bin/prod/build-frontend

--- a/bin/prod/build-frontend
+++ b/bin/prod/build-frontend
@@ -1,0 +1,18 @@
+#! /usr/bin/env bash
+
+# This script builds the frontend bundle
+#
+# Usage: ./bin/prod/build-frontend
+
+SCRIPT_DIR=$(dirname "$0")
+
+main() {
+  local frontend_dir="$SCRIPT_DIR/../../frontend"
+  (
+    cd "$frontend_dir"
+    yarn
+    yarn build
+  )
+}
+
+main "$@"

--- a/bin/prod/run-app
+++ b/bin/prod/run-app
@@ -6,23 +6,9 @@
 
 SCRIPT_DIR=$(dirname "$0")
 
-# Here we are using webpack to build the frontend assets that will be dumped into app/static
-build_assets() {
-  local frontend_dir="$SCRIPT_DIR/../../frontend"
-  (
-    cd "$frontend_dir"
-    yarn
-    yarn build
-  )
-}
-
-run_server() {
-  "$SCRIPT_DIR/../dev/run-backend"
-}
-
 main() {
   export ENVIRONMENT="production"
-  build_assets
+  "${SCRIPT_DIR}/build-frontend"
   run_server
 }
 


### PR DESCRIPTION
This starts off running CI with just a single check that we can easily do, which is to make sure that the frontend builds in production mode.

Ideally, we will be adding to the checks that get run, including running the Python test suite, but a lot of that is blocked by some some of the configuration and secrets management stuff.